### PR TITLE
Fix FPs

### DIFF
--- a/modules/signatures/antisandbox_unhook.py
+++ b/modules/signatures/antisandbox_unhook.py
@@ -65,6 +65,9 @@ class Unhook(Signature):
                         "WinHttpConnect",
                         "WinHttpReceiveResponse",
                         "WinHttpQueryHeaders",
+                        "NetUserGetInfo",
+                        "NetGetJoinInformation",
+                        "NetUserGetLocalGroups",
                     ]
                     for name in allowed:
                         if funcname == name:


### PR DESCRIPTION
Happens in instances where we use IE to browse to a URL which has basic auth and Windows auto-attempts to use Windows credentials manager to process auth.
