### PR TITLE
Tighten crypto threshold for Nanocore

### DIFF
--- a/modules/signatures/rat_nanocore.py
+++ b/modules/signatures/rat_nanocore.py
@@ -29,7 +29,7 @@ class NanocoreRAT(Signature):
     def __init__(self, *args, **kwargs):
         Signature.__init__(self, *args, **kwargs)
         self.cryptcalls = 0
-        self.cryptmz = False
+        self.cryptmz = 0
 
     filter_apinames = set(["CryptHashData"])
 
@@ -41,7 +41,7 @@ class NanocoreRAT(Signature):
                 if buf.endswith(tail):
                     self.cryptcalls += 1
                 if buf.startswith("MZ"):
-                    self.cryptmz = True
+                    self.cryptmz += 1
 
     def on_complete(self):
         badness = 0
@@ -61,7 +61,9 @@ class NanocoreRAT(Signature):
         if self.check_mutex(pattern=mutex, regex=True):
             badness += 1
 
-        if self.cryptmz and self.cryptcalls:
+        if self.cryptmz >= 2 and self.cryptcalls:
+            if self.cryptcalls > 4:
+                self.cryptcalls = 4
             badness += self.cryptcalls
 
         if badness >= 5:

--- a/modules/signatures/rat_nanocore.py
+++ b/modules/signatures/rat_nanocore.py
@@ -17,7 +17,7 @@ from lib.cuckoo.common.abstracts import Signature
 
 class NanocoreRAT(Signature):
     name = "rat_nanocore"
-    desctipnion = "Exhibits behavior characteristic of Nanocore RAT"
+    description = "Exhibits behavior characteristic of Nanocore RAT"
     weight = 3
     severity = 3
     categories = ["rat"]


### PR DESCRIPTION
Observed a similar obfuscator being used in a Hawkeye sample -- So we'll tighten the primary crypto threshold and also limit the effect of the crypto ioc so that we need to match it with either a file or mutex ioc as well.
