### PR TITLE
Remove severity adjustments to severity 3 & some whitelisting

### DIFF
--- a/modules/signatures/network_cnc_http.py
+++ b/modules/signatures/network_cnc_http.py
@@ -18,7 +18,8 @@ class NetworkCnCHTTP(Signature):
     def run(self):
 
         whitelist = [
-            "^http://crl\.microsoft\.com/.*",
+            "^http://.*\.microsoft\.com/.*",
+            "^http://.*\.windowsupdate\.com/.*",
             "http://.*\.adobe\.com/.*",
             ]
 
@@ -51,17 +52,14 @@ class NetworkCnCHTTP(Signature):
 
         if post_noreferer > 0:
             self.data.append({"post_no_referer" : "HTTP traffic contains a POST request with no referer header" })
-            self.severity = 3
             self.weight += 1
 
         if post_nouseragent > 0:
             self.data.append({"post_no_useragent" : "HTTP traffic contains a POST request with no user-agent header" })
-            self.severity = 3
             self.weight += 1
 
         if get_nouseragent > 0:
             self.data.append({"get_no_useragent" : "HTTP traffic contains a GET request with no user-agent header" })
-            self.severity = 3
             self.weight += 1
 
         if version1 > 0:


### PR DESCRIPTION
Removing increases in severity due to potential for other factors in a sandbox to cause such traffic until the signature can be improved to report on interesting requests rather than the generic catch all.

Microsoft signature has been changed too not to focus on crl as go.microsoft.com, sql.microsoft.com etc also trigger this. Add in windowsupdate the now too due to its prevalence and future FP potential.
