### PR TITLE
Add in various features and display requests

### DIFF
--- a/modules/signatures/network_cnc_http.py
+++ b/modules/signatures/network_cnc_http.py
@@ -7,13 +7,15 @@ from lib.cuckoo.common.abstracts import Signature
 
 class NetworkCnCHTTP(Signature):
     name = "network_cnc_http"
-    description = "HTTP traffic contains features indicative of potential command and control activity"
+    description = "HTTP traffic contains suspicious features which may be indicative of malware related traffic"
     severity = 2
     confidence = 30
     weight = 0
     categories = ["http", "cnc"]
     authors = ["Kevin Ross"]
     minimum = "1.3"
+
+    filter_analysistypes = set(["file"])
 
     def run(self):
 
@@ -28,7 +30,12 @@ class NetworkCnCHTTP(Signature):
         post_nouseragent = 0
         get_nouseragent = 0
         version1 = 0
-        long_uri = 0
+        iphost = 0
+        offport = 0
+
+        # Scoring
+        cnc_score = 0
+        suspectrequest = []
 
         if "network" in self.results and "http" in self.results["network"]:
             for req in self.results["network"]["http"]:
@@ -38,17 +45,34 @@ class NetworkCnCHTTP(Signature):
                         is_whitelisted = True                              
 
                 # Check HTTP features
+                request = req["uri"]
+                ip = re.compile("^http\:\/\/\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}")
                 if not is_whitelisted and req["method"] == "POST" and "Referer:" not in req["data"]:
                     post_noreferer += 1
+                    cnc_score += 1
 
                 if not is_whitelisted and req["method"] == "POST" and "User-Agent:" not in req["data"]:
                     post_nouseragent += 1
+                    cnc_score += 1
 
                 if not is_whitelisted and req["method"] == "GET" and "User-Agent:" not in req["data"]:
                     get_nouseragent += 1
 
                 if not is_whitelisted and req["version"] == "1.0":
                     version1 += 1
+                    cnc_score += 1
+
+                if not is_whitelisted and ip.match(request):
+                    iphost += 1
+                    cnc_score += 1
+
+                if not is_whitelisted and req["port"] != "80":
+                    offport += 1
+                    cnc_score += 1
+
+                if not is_whitelisted and cnc_score > 0:
+                    if suspectrequest.count(request) == 0:
+                        suspectrequest.append(request)
 
         if post_noreferer > 0:
             self.data.append({"post_no_referer" : "HTTP traffic contains a POST request with no referer header" })
@@ -65,6 +89,18 @@ class NetworkCnCHTTP(Signature):
         if version1 > 0:
             self.data.append({"http_version_old" : "HTTP traffic uses version 1.0" })
             self.weight += 1
+
+        if iphost > 0:
+            self.data.append({"ip_hostname" : "HTTP connection was made to an IP address rather than domain name" })
+            self.weight += 1
+
+        if offport > 0:
+            self.data.append({"non_standard_port" : "HTTP connection was made to port other than port 80" })
+            self.weight += 1
+
+        if self.weight and len(suspectrequest) > 0:
+            for request in suspectrequest:
+                self.data.append({"suspicious_request" : request})
 
         if self.weight:
             return True


### PR DESCRIPTION
Made various changes:
- Added in new features for request to IP address rather than hostname and also HTTP requests not to port 80.
- Changed description to be less convicting of actual CnC and more suspiciousness and possibility it is related.
- Added in changes to allow for any requests which match on the features to be shown after a summary features seen from host.
- Removed unused long_uri check which was too FP prone
- Set analysis type to file to ensure it is not a URL.

Also as a side note the requested changes to Radamant, Proxyback & PDF changes have already been submitted if they can please be looked a to determine if they are now ok for merging.
