### PR TITLE
Create signature for doc file initiating network comms

### DIFF
--- a/modules/signatures/network_docfile_http.py
+++ b/modules/signatures/network_docfile_http.py
@@ -1,0 +1,63 @@
+# Copyright (C) 2016 Kevin Ross. Also uses code by Will Metcalf
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from lib.cuckoo.common.abstracts import Signature
+
+try:
+    import re2 as re
+except ImportError:
+    import re
+
+class NetworkDocumentHTTP(Signature):
+    name = "network_document_http"
+    description = "A document file initiated network communications indicative of a potential exploit or payload download"
+    severity = 3
+    confidence = 20
+    categories = ["virus", "exploit"]
+    authors = ["Kevin Ross", "Will Metcalf"]
+    minimum = "1.2"
+    evented = True
+    match = True
+
+    def __init__(self, *args, **kwargs):
+        Signature.__init__(self, *args, **kwargs)
+        self.data = []
+        self.office_proc_list =["wordview.exe","winword.exe","excel.exe","powerpnt.exe","outlook.exe","acrord32.exe","acrord64.exe"]     
+
+    filter_apinames = set(["InternetCrackUrlW","InternetCrackUrlA","URLDownloadToFileW","HttpOpenRequestW","InternetReadFile"])
+    filter_analysistypes = set(["file"])
+
+    def on_call(self, call, process):
+        pname = process["process_name"].lower()
+        if pname in self.office_proc_list:
+            if call["api"] == "URLDownloadToFileW":
+                buff = self.get_argument(call, "FileName").lower()
+                self.data.append({"http_filename": "%s_URLDownloadToFileW_%s" % (pname,buff)})
+            if call["api"] == "HttpOpenRequestW":
+                buff = self.get_argument(call, "Path").lower()
+                self.data.append({"http_request_path": "%s_HttpOpenRequestW_%s" % (pname,buff)})
+            if call["api"] == "InternetCrackUrlW":
+                buff = self.get_argument(call, "Url").lower()
+                self.data.append({"http_request": "%s_InternetCrackUrlW_%s" % (pname,buff)})
+            if call["api"] == "InternetCrackUrlA":
+                buff = self.get_argument(call, "Url").lower()
+                self.data.append({"http_request": "%s_InternetCrackUrlA_%s" % (pname,buff)})
+        return None
+
+    def on_complete(self):
+        if self.data:
+            return True
+        else:
+            return False


### PR DESCRIPTION
Create a signature to detect when a document file (Office/PDF) initiates network communications. I whitelist may need to be added at a later date depending on FPs but my sandbox has not produced any. 

The aim of the signature is to detect exploit payloads or other features - especially in a closed sandbox environment where other malicious features may not be revealed by signatures and so this helps makes these connections more visible as a document should not make random connections when executed in a sandbox under normal conditions.  This has been tested against old and new Dridex doc samples and MWI document exploits.
