### PR TITLE
Add in new author noted in Dridex campaigns

### DIFF
--- a/modules/signatures/office_macro.py
+++ b/modules/signatures/office_macro.py
@@ -99,7 +99,7 @@ class Office_Macro(Signature):
             if "Metadata" in self.results["static"]["office"]:
                 if "SummaryInformation" in self.results["static"]["office"]["Metadata"]:
                     author = self.results["static"]["office"]["Metadata"]["SummaryInformation"]["author"]
-                    if author == "1" or author == "Alex" or author == "Microsoft Office":
+                    if author == "1" or author == "Alex" or author == "Microsoft Office" or author == "Adder":
                         self.severity = 3
                         self.weight += 2
                         self.data.append({"author" : "The file appears to have been created by a known fake author indicative of an automated document creation kit."})


### PR DESCRIPTION
Added in another author seen in Dridex campaigns. Also is the network document traffic signature that has not been merged ok or is there work that needs done? I have found it never useful in macro campaigns if analysing in a closed sandbox and the EXE is unavailable to make it available to others the download paths to track.
