### PR TITLE
Various author detection changes

### DIFF
--- a/modules/signatures/office_macro.py
+++ b/modules/signatures/office_macro.py
@@ -13,6 +13,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+try:
+    import re2 as re
+except ImportError:
+    import re
+
 from lib.cuckoo.common.abstracts import Signature
 
 class Office_Macro(Signature):
@@ -20,7 +25,7 @@ class Office_Macro(Signature):
     description = "The office file has a macro."
     severity = 2
     categories = ["office"]
-    authors = ["KillerInstinct"]
+    authors = ["KillerInstinct","Kevin Ross"]
     minimum = "1.3"
 
     def run(self):
@@ -98,10 +103,52 @@ class Office_Macro(Signature):
         if ret and "static" in self.results and "office" in self.results["static"]:
             if "Metadata" in self.results["static"]["office"]:
                 if "SummaryInformation" in self.results["static"]["office"]["Metadata"]:
-                    author = self.results["static"]["office"]["Metadata"]["SummaryInformation"]["author"]
-                    if author == "1" or author == "Alex" or author == "Microsoft Office" or author == "Adder":
+                    creating_app = self.results["static"]["office"]["Metadata"]["SummaryInformation"]["creating_application"]
+                    if creating_app == "None":
                         self.severity = 3
                         self.weight += 2
-                        self.data.append({"author" : "The file appears to have been created by a known fake author indicative of an automated document creation kit."})
+                        self.data.append({"no_creating_app" : "The file appears to have no creating application indicative of it being malformed or created by an automated document creation kit"})
+
+        if ret and "static" in self.results and "office" in self.results["static"]:
+            if "Metadata" in self.results["static"]["office"]:
+                if "SummaryInformation" in self.results["static"]["office"]["Metadata"]:
+                    author = self.results["static"]["office"]["Metadata"]["SummaryInformation"]["author"]
+                    lastauthor = self.results["static"]["office"]["Metadata"]["SummaryInformation"]["last_saved_by"]
+                    known_authors = ["Alex","Microsoft Office","Adder"]
+                    numerical_author = re.compile("^[0-9]{1,}$")
+                    for known_authors in known_authors:
+                        if author == known_authors:
+                            self.severity = 3
+                            self.weight += 2
+                            self.data.append({"malicious_author" : "The file appears to have been created by a known fake author indicative of an automated document creation kit."})
+
+                    if numerical_author.match(author):
+                        self.severity = 3
+                        self.weight += 2
+                        self.data.append({"numerical_author" : "The file author is numerical rather than a word/name indicative of an automated document creation kit."})
+
+                    if re.search("[0-9]{1}", author) and re.search("[A-Z]{1}", author):
+                        if len(author) < 6 and re.match("^[a-zA-Z0-9]{1,5}$", author):
+                            self.severity = 3
+                            self.weight += 2
+                            self.data.append({"short_author_format" : "The file author has little text yet contains numerical and upper case characters in it indicative of an automated document creation kit."})
+                        if len(author) > 5 and re.match("^[a-zA-Z0-9].*[A-Z].*$", author):
+                           if re.match("^[a-zA-Z0-9]{6,}$", author):
+                               self.data.append({"author_format" : "The file author contains a mix of numerical and upper case characters in an unlikely pattern indicative of an automated document creation kit."})
+
+                    if numerical_author.match(lastauthor):
+                        self.severity = 3
+                        self.weight += 2
+                        self.data.append({"numerical_last_saved" : "The file was last saved by a numerical author rather than a word/name indicative of an automated document creation kit."})
+
+                    if re.search("[0-9]{1}", lastauthor) and re.search("[A-Z]{1}", lastauthor):
+                        if len(lastauthor) < 6 and re.match("^[a-zA-Z0-9]{1,5}$", lastauthor):
+                            self.severity = 3
+                            self.weight += 2
+                            self.data.append({"short_last_saved_format" : "he file was last saved by an author with little text yet contains numerical and upper case characters in it indicative of an automated document creation kit."})
+
+                        if len(lastauthor) > 5 and re.match("^[a-zA-Z0-9].*[A-Z].*$", lastauthor):
+                           if re.match("^[a-zA-Z0-9]{6,}$", lastauthor):
+                               self.data.append({"last_saved_format" : "The file was last saved by an author containing a mix of numerical and upper case characters in an unlikely pattern indicative of an automated document creation kit."})
 
         return ret

--- a/modules/signatures/office_macro.py
+++ b/modules/signatures/office_macro.py
@@ -103,15 +103,6 @@ class Office_Macro(Signature):
         if ret and "static" in self.results and "office" in self.results["static"]:
             if "Metadata" in self.results["static"]["office"]:
                 if "SummaryInformation" in self.results["static"]["office"]["Metadata"]:
-                    creating_app = self.results["static"]["office"]["Metadata"]["SummaryInformation"]["creating_application"]
-                    if creating_app == "None":
-                        self.severity = 3
-                        self.weight += 2
-                        self.data.append({"no_creating_app" : "The file appears to have no creating application indicative of it being malformed or created by an automated document creation kit"})
-
-        if ret and "static" in self.results and "office" in self.results["static"]:
-            if "Metadata" in self.results["static"]["office"]:
-                if "SummaryInformation" in self.results["static"]["office"]["Metadata"]:
                     author = self.results["static"]["office"]["Metadata"]["SummaryInformation"]["author"]
                     lastauthor = self.results["static"]["office"]["Metadata"]["SummaryInformation"]["last_saved_by"]
                     known_authors = ["Alex","Microsoft Office","Adder"]


### PR DESCRIPTION
Add in the following changes:
- make author list a dictionary and use for loop to make adding new malicious authors easier
- Add in checks for entirely numerical authors. While Dridex used "1" before repeatedly I have noticed others with numbers only and Dridex has recently also started using "3". Thus it is simpler to just detect this anomaly.
- Add in checks for suspicious format. Suspicious format is determined by a) containing at least one upper case character b) containing at least one number. Also if the length is over 5 characters in length the additional requirement of having 2 upper case characters is introduced and no whitespace or deliminating characters (i.e not Kevin.Ross1 which could be reasonable if multiple kevin ross users existed in a organisation). These checks better detect other document creation kits and will deal with any FP reports althoug the macro requirement should hopefully limit this.
- Add most of these above checks for numbers and fomat into last_saved too. 
- Added my name also in as an author to the signature given decent levels of contributions to the original work.
