### PR TITLE
Add in extraction for GET no UA

### DIFF
--- a/modules/signatures/network_cnc_http.py
+++ b/modules/signatures/network_cnc_http.py
@@ -56,6 +56,7 @@ class NetworkCnCHTTP(Signature):
 
                 if not is_whitelisted and req["method"] == "GET" and "User-Agent:" not in req["data"]:
                     get_nouseragent += 1
+                    cnc_score += 1
 
                 if not is_whitelisted and req["version"] == "1.0":
                     version1 += 1


### PR DESCRIPTION
Add in CnC score to GET no user agent indicator. This was not present due to other use of the scoring in early iterations. As more useful specific indicators are added this may be revised or utilised differently but right now it is necessary to extract and display the request as appended data also.
