### PR TITLE
Make teslacrypt the primary family name used as this is the accepted …

### DIFF
--- a/modules/signatures/alphacrypt_apis.py
+++ b/modules/signatures/alphacrypt_apis.py
@@ -26,7 +26,7 @@ class Alphacrypt_APIs(Signature):
     weight = 3
     severity = 3
     categories = ["ransomware"]
-    families = ["alphacrypt", "teslacrypt"]
+    families = ["teslacrypt", "alphacrypt"]
     authors = ["KillerInstinct"]
     minimum = "1.2"
     evented = True


### PR DESCRIPTION
…common name for this family.
