### PR TITLE
Whitelist some default behavior

### DIFF
--- a/modules/signatures/stealth_file.py
+++ b/modules/signatures/stealth_file.py
@@ -127,7 +127,7 @@ class StealthFile(Signature):
             r'^[A-Z]?:\\Users\\[^\\]+\\AppData\\Local\\Microsoft\\Windows\\History\\History\.IE5\\MSHist[0-9]+\\index\.dat$',
         ]
         url_whitelist = [
-            r'^[A-Z]?:\\Users\\[^\\]+\\AppData\\Roaming\\Microsoft\\Windows\\Recent\\CustomDestiantions\\.*\.customDestinations.*\.TMP$',
+            r'^[A-Z]?:\\Users\\[^\\]+\\AppData\\Roaming\\Microsoft\\Windows\\Recent\\CustomDestinations\\.*\.customDestinations.*\.TMP$',
         ]
         saw_stealth = False
         target_name = None

--- a/modules/signatures/stealth_file.py
+++ b/modules/signatures/stealth_file.py
@@ -126,12 +126,18 @@ class StealthFile(Signature):
             r'^[A-Z]?:\\Users\\[^\\]+\\AppData\\Local\\Microsoft\\Windows\\History\\History\.IE5\\MSHist[0-9]+\\$',
             r'^[A-Z]?:\\Users\\[^\\]+\\AppData\\Local\\Microsoft\\Windows\\History\\History\.IE5\\MSHist[0-9]+\\index\.dat$',
         ]
+        url_whitelist = [
+            r'^[A-Z]?:\\Users\\[^\\]+\\AppData\\Roaming\\Microsoft\\Windows\\Recent\\CustomDestiantions\\.*\.customDestinations.*\.TMP$',
+        ]
         saw_stealth = False
         target_name = None
 
         if self.is_office and "file" in self.results["target"]:
             target_name = self.results["target"]["file"]["name"]
-            
+
+        if "url" in self.results["target"]:
+            whitelist.extend(url_whitelist)
+
         for hfile in self.stealth_files:
             addit = True
             for entry in whitelists:


### PR DESCRIPTION
Observed with IE8 on Win7 x86. Any downloaded file (where a content disposition pops up a download and we click "save" or "open") from IE creates a similar looking .tmp hidden file.
