### PR TITLE
Create ek_cve2015_2419.py

### DIFF
--- a/modules/signatures/ek_cve2015_2419.py
+++ b/modules/signatures/ek_cve2015_2419.py
@@ -1,0 +1,28 @@
+from lib.cuckoo.common.abstracts import Signature
+
+class CVE2015_2419_JS(Signature):
+    name = "cve_2015_2419_js"
+    description = "Executes obfuscated JavaScript containing CVE-2015-2419 Internet Explorer Jscript9 JSON.stringify double free memory corruption attempt"
+    severity = 3
+    categories = ["exploit"]
+    authors = ["Kevin Ross"]
+    minimum = "1.3"
+    references = ["https://www.fireeye.com/blog/threat-research/2015/08/cve-2015-2419_inte.html", "blog.checkpoint.com/2016/02/10/too-much-freedom-is-dangerous-understanding-ie-11-cve-2015-2419-exploitation/"]
+    evented = True
+
+    def __init__(self, *args, **kwargs):
+        Signature.__init__(self, *args, **kwargs)
+
+    filter_categories = set(["browser"])
+    # backward compat
+    filter_apinames = set(["JsEval", "COleScript_Compile", "COleScript_ParseScriptText"])
+
+    def on_call(self, call, process):
+
+        if call["api"] == "JsEval":
+            buf = self.get_argument(call, "Javascript")
+        else:
+            buf = self.get_argument(call, "Script")
+
+        if "JSON[" in buf and "prototype" in buf and "stringify" in buf:
+            return True

--- a/modules/signatures/ek_cve2015_2419.py
+++ b/modules/signatures/ek_cve2015_2419.py
@@ -1,3 +1,18 @@
+# Copyright (C) 2015 Kevin Ross
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 from lib.cuckoo.common.abstracts import Signature
 
 class CVE2015_2419_JS(Signature):

--- a/modules/signatures/ek_cve2015_2419.py
+++ b/modules/signatures/ek_cve2015_2419.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2015 Kevin Ross
+# Copyright (C) 2016 Kevin Ross
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Add in specific signature for this exploit. The idea will be to eventually collapse some sigs into a sig with indicators and specific exploits defined for IE and things (ones being exploited in wild though only because don't want to go crazy; just provide extra info). Tried doing this already but did not work but didn't have long to look at why when defining this check and trying to get the heaps spray sig cleaned up alongside it.

Just providing this though the now given it is still being exploited by some EKs so may be useful at least for a while.
