### PR TITLE
Fix return

### DIFF
--- a/modules/signatures/ransomware_filemodifications.py
+++ b/modules/signatures/ransomware_filemodifications.py
@@ -74,6 +74,6 @@ class RansomwareFileModifications(Signature):
                 self.data.append({"appends_new_extension" : "Appends a new file extension to multiple modified files" })
                 for newextension in self.newextensions:
                     self.data.append({"new_appended_file_extension" : newextension})
-                ret = True
+            ret = True
 
         return ret


### PR DESCRIPTION
If the append count was between 16-40 and move count <0 100, we wouldn't trigger the signature, despite having a high amount of separate extension appends.
