### PR TITLE
Handle shortpaths for executed commands args

### DIFF
--- a/modules/signatures/ursnif_apis.py
+++ b/modules/signatures/ursnif_apis.py
@@ -53,8 +53,14 @@ class Ursnif_APIs(Signature):
                         buf = command.split("\"")
                         arg1 = arg1.replace("\"", "")
                         arg2 = arg2.replace("\"", "")
-                        if arg1 in buf and arg2 in buf:
-                            badness += 8
+                        if arg2 in buf:
+                            if arg1 in buf:
+                                badness += 8
+                            # Handle shortnames
+                            elif "~1" in arg1:
+                                tmp = arg1.split("~1")
+                                if all(z in buf for z in tmp):
+                                    badness += 8
                     else:
                         pass
 


### PR DESCRIPTION
Untested code, but it should fix the case (in XP) where we have a short path in our executed commands summary.
