### PR TITLE
Add in new generic dropped files technique

### DIFF
--- a/modules/signatures/ransomware_filemodifications.py
+++ b/modules/signatures/ransomware_filemodifications.py
@@ -71,7 +71,7 @@ class RansomwareFileModifications(Signature):
                 if mimetype == "data":
                     droppedunknowncount += 1  
             if droppedunknowncount > 500:
-                self.data.append({"drops_unknown_mimetypes" : "Drops %s unknown file mime types which may be indicative of encrypted files being written back to disk" % (droppedunknowncount)})
+                self.data.append({"drops_unknown_mimetypes" : "Drops %s files with an unknown mime type which may be indicative of encrypted files being written back to disk" % (droppedunknowncount)})
                 ret = True   
 
         # Note: Always make sure this check is at bottom so that appended file extensions are underneath behavior alerts

--- a/modules/signatures/ransomware_filemodifications.py
+++ b/modules/signatures/ransomware_filemodifications.py
@@ -68,11 +68,12 @@ class RansomwareFileModifications(Signature):
             droppedunknowncount = 0
             for dropped in self.results["dropped"]:
                 mimetype = dropped["type"]
-                if mimetype == "data":
-                    droppedunknowncount += 1  
-            if droppedunknowncount > 500:
-                self.data.append({"drops_unknown_mimetypes" : "Drops %s files with an unknown mime type which may be indicative of encrypted files being written back to disk" % (droppedunknowncount)})
-                ret = True   
+                filename = dropped["name"]
+                if mimetype == "data" and ".tmp" not in filename:
+                    droppedunknowncount += 1            
+            if droppedunknowncount > 50:
+                self.data.append({"drops_unknown_mimetypes" : "Drops %s unknown file mime types which may be indicative of encrypted files being written back to disk" % (droppedunknowncount)})
+                ret = True 
 
         # Note: Always make sure this check is at bottom so that appended file extensions are underneath behavior alerts
         if self.appendcount > 40:

--- a/modules/signatures/ransomware_filemodifications.py
+++ b/modules/signatures/ransomware_filemodifications.py
@@ -63,6 +63,16 @@ class RansomwareFileModifications(Signature):
         if self.movefilecount > 60:
             self.data.append({"file_modifications" : "Performs %s file moves indicative of a potential file encryption process" % (self.movefilecount)})
             ret = True
+            
+        if "dropped" in self.results:
+            droppedunknowncount = 0
+            for dropped in self.results["dropped"]:
+                mimetype = dropped["type"]
+                if mimetype == "data":
+                    droppedunknowncount += 1  
+            if droppedunknowncount > 500:
+                self.data.append({"drops_unknown_mimetypes" : "Drops %s unknown file mime types which may be indicative of encrypted files being written back to disk" % (droppedunknowncount)})
+                ret = True   
 
         # Note: Always make sure this check is at bottom so that appended file extensions are underneath behavior alerts
         if self.appendcount > 40:


### PR DESCRIPTION
Add in a new technique to detect ransomware regardless of API calls used (moved files, create files etc) that ransomware may use. I simply check if a large number of files have been dropped with the type being "data" which means it is unrecognised. This can be tuned further later to be a bit more accurate and also to integrate it into the appended file extensions if a large number of files have same extension appended to double file extension (a change for later).

For now this should provide a useful indicator of ransomware regardless of the family.
