### PR TITLE
Add signature for desktop wallpaper modifications

### DIFF
--- a/modules/signatures/modifies_wallpaper.py
+++ b/modules/signatures/modifies_wallpaper.py
@@ -1,0 +1,30 @@
+# Copyright (C) 2016 Kevin Ross
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from lib.cuckoo.common.abstracts import Signature
+
+class ModifiesDesktopWallpaper(Signature):
+    name = "modifies_desktop_wallpaper"
+    description = "Attempts to modify desktop wallpaper"
+    severity = 3
+    categories = ["ransomware"]
+    authors = ["Kevin Ross"]
+    minimum = "1.3"
+
+    def run(self):
+        if self.check_write_key(pattern=".*\\\\Control\\ Panel\\\\Desktop\\\\Wallpaper$", regex=True):
+            return True
+
+        return False


### PR DESCRIPTION
This is a common thing where some ransomware families may set the desktop background to be the ransom message (i.e Locky)
