### PR TITLE
Fix traceback

### DIFF
--- a/modules/signatures/ipc_namedpipe.py
+++ b/modules/signatures/ipc_namedpipe.py
@@ -66,7 +66,7 @@ class IPC_NamedPipe(Signature):
 
     def on_complete(self):
         ret = False
-        if self.ipc:
+        if self.ipc and self.created:
             for ipc in self.ipc:
                 # Check if more than one pid interacted with a pipe
                 if len(self.ipc[ipc]) > 1:

--- a/modules/signatures/ipc_namedpipe.py
+++ b/modules/signatures/ipc_namedpipe.py
@@ -66,8 +66,14 @@ class IPC_NamedPipe(Signature):
 
     def on_complete(self):
         ret = False
+        ipcs = list()
         if self.ipc and self.created:
-            for ipc in self.ipc:
+            for ipc in self.created.keys():
+                if ipc in self.ipc:
+                    ipcs.append(ipc)
+
+        if ipcs:
+            for ipc in ipcs:
                 # Check if more than one pid interacted with a pipe
                 if len(self.ipc[ipc]) > 1:
                     ret = True


### PR DESCRIPTION
This traceback happens when we don't observe any winapi to NtCreateNamedPipeFile. Since we are accounting for child processes to create the pipe, we need to check to see it the creation happened in a process we saw. If it didn't (EG some service management/IE backending) this would cause a traceback as we didn't see the creation event, but saw the NtWriteFile to the service pipe.
