### PR TITLE
Update debugs_self.py

### DIFF
--- a/modules/signatures/debugs_self.py
+++ b/modules/signatures/debugs_self.py
@@ -34,7 +34,7 @@ class DebugsSelf(Signature):
        applicationname = self.get_argument(call, "ApplicationName").lower()
        pid = self.get_argument(call, "ProcessId")
        if createflags & 1:
-           for proc in results["behavior"]["processes"]:
+           for proc in self.results["behavior"]["processes"]:
                if proc["process_id"] == pid and proc["module_path"].lower() == process["module_path"].lower():
                    # DEBUG_PROCESS on a copy of ourselves
                    return True


### PR DESCRIPTION
i think **self.results** instead of **results** no?

```
Traceback (most recent call last):
  File "/opt/cuckoo-modified/utils/../lib/cuckoo/core/plugins.py", line 414, in run
    result = sig.on_call(call, proc)
  File "/opt/cuckoo-modified/utils/../modules/signatures/debugs_self.py", line 37, in on_call
    for proc in results["behavior"]["processes"]:
NameError: global name 'results' is not defined
```
