### PR TITLE
Remove FP

### DIFF
--- a/modules/signatures/ransomware_filemodifications.py
+++ b/modules/signatures/ransomware_filemodifications.py
@@ -71,7 +71,7 @@ class RansomwareFileModifications(Signature):
                 filename = dropped["name"]
                 if mimetype == "data" and ".tmp" not in filename:
                     droppedunknowncount += 1            
-            if droppedunknowncount > 50:
+            if droppedunknowncount > 50 and self.results["info"]["package"] != "pdf":
                 self.data.append({"drops_unknown_mimetypes" : "Drops %s unknown file mime types which may be indicative of encrypted files being written back to disk" % (droppedunknowncount)})
                 ret = True 
 


### PR DESCRIPTION
Reader was dropping various 'journaling' SQLite DBs and due to libmagic's failure to work properly, it would get detected as data. For now we can just ignore the PDF package.
