### PR TITLE
Add in severity 1 sig for computername query

### DIFF
--- a/modules/signatures/antivm_computername.py
+++ b/modules/signatures/antivm_computername.py
@@ -1,0 +1,30 @@
+# Copyright (C) 2016 Kevin Ross
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from lib.cuckoo.common.abstracts import Signature
+
+class AntiVMComputernameQuery(Signature):
+    name = "antivm_queries_computername"
+    description = "Queries for the computername"
+    severity = 1
+    categories = ["AntiVM"]
+    authors = ["Kevin Ross"]
+    minimum = "1.3"
+    evented = True
+
+    filter_apinames = set(["GetComputerNameA","GetComputerNameW","GetComputerNameExA","GetComputerNameExW"])
+
+    def on_call(self, call, process):
+        return True


### PR DESCRIPTION
Just for extra information & username sig coming too. This is the real sig I want to get complete and then converted back (this sig works well for Dridex but I need a lot more building of it):

https://github.com/cuckoosandbox/community/pull/120

Once i have this signature working fully with all necessary APis, data and ways it is used I will convert it back. As I have been doing a lot of cuckoo-2.0 stuff it was easier to get the data flagged there and then I will look at getting the appended data, deduplication etc done for modified but hopefully it could end up being a useful sig for identifying how CnC is constructed or that it is setting up for CnC. 

On a side note cuckoo 2.0 signature conversions are going ok and I am making sure everything is properly credited in the signature and the pull requests are linked to any of the original content on cuckoo-modified. I am doing what I can; obviously there is a lot that can't come over currently and there is also behaviour results not being followed right such as injections or process injections not followed, unlreated processes being included in results or even process creation not being followed it seems. Still I am reporting everything I find there and requesting features. Hopefully the spare time I spend doing this will be useful to the cuckoo community. 

Still cuckoo-modified is my production and prefered sandbox. While I know I have said amazing job before you have done with this (as well as others) & doing comparisons and really digging into the activities the quality is awesome so thanks again!
