### PR TITLE
Fix traceback

### DIFF
--- a/modules/signatures/banker_zeus_p2p.py
+++ b/modules/signatures/banker_zeus_p2p.py
@@ -47,7 +47,7 @@ class ZeusP2P(Signature):
         # IP is really valid.
         count = 0
         if "network" in self.results:
-            for udp in self.results["network"]["udp"]:
+            for udp in self.results.get("network", {}).get("udp",[]):
                 if udp["dport"] > 1024:
                     count += 1
             


### PR DESCRIPTION
When there is no pcap there is no udp:
Traceback (most recent call last):
  File "/opt/cuckoo/utils/../lib/cuckoo/core/plugins.py", line 351, in process
    data = current.run()
  File "/opt/cuckoo/utils/../modules/signatures/banker_zeus_p2p.py", line 50, in run
    for udp in self.results["network"]["udp"]:
KeyError: 'udp'
