### PR TITLE
Create signature for computer details used in C2

### DIFF
--- a/modules/signatures/network_c2_details.py
+++ b/modules/signatures/network_c2_details.py
@@ -1,0 +1,93 @@
+# Copyright (C) 2016 Kevin Ross
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from lib.cuckoo.common.abstracts import Signature
+
+class NetworkC2Details(Signature):
+    name = "network_c2_details"
+    description = "Queried details from the computer were then used in a network or crypto API call indicative of command and control communications/preperations"
+    severity = 3
+    confidence = 20
+    categories = ["infostealer","c2","network"]
+    authors = ["Kevin Ross"]
+    minimum = "1.3"
+    evented = True
+
+    def __init__(self, *args, **kwargs):
+        Signature.__init__(self, *args, **kwargs)
+        self.computerdetails = []
+        self.cnc = False
+
+    filter_apinames = set(["GetComputerNameA","GetUserNameA","GetComputerNameW","GetUserNameW","CryptHashData","HttpSendRequestW","HttpOpenRequestW","InternetCrackUrlW","WSASend"])
+    filter_analysistypes = set(["file"])
+
+    def on_call(self, call, process):
+        # Here we check for interesting bits of data which may be queried and used in cnc for computer identification
+        api = call["api"]
+        if api == "GetComputerNameA" or api == "GetComputerNameW":
+            compname = self.get_argument(call, "ComputerName")
+            if compname:
+                self.computerdetails.append(compname)
+
+        elif api == "GetUserNameA" or api == "GetUserNameW":
+            username = self.get_argument(call, "UserName")
+            if username:
+                self.computerdetails.append(username)
+
+        elif api == "CryptHashData":
+            buff = self.get_argument(call, "Buffer")
+            for compdetails in self.computerdetails:
+                if compdetails in buff:
+                    if self.computerdetails.count(buff) == 0:
+                        self.data.append({"C2_Preperation_CryptoHashData": buff})
+                        self.cnc = True
+
+        elif api == "HttpSendRequestW":
+            buff = self.get_argument(call, "PostData")
+            for compdetails in self.computerdetails:
+                if compdetails in buff:
+                    if self.computerdetails.count(buff) == 0:
+                        self.data.append({"C2_HttpSendRequestW": buff})
+                        self.cnc = True
+
+        elif api == "HttpOpenRequestW":
+            buff = self.get_argument(call, "Path")
+            for compdetails in self.computerdetails:
+                if compdetails in buff:
+                    if self.computerdetails.count(buff) == 0:
+                        self.data.append({"C2_HttpOpenRequestW": buff})
+                        self.cnc = True
+
+        elif api == "InternetCrackUrlW":
+            buff = self.get_argument(call, "Url")
+            for compdetails in self.computerdetails:
+                if compdetails in buff:
+                    if self.computerdetails.count(buff) == 0:
+                        self.data.append({"C2_InternetCrackUrlW": buff})
+                        self.cnc = True
+
+        elif api == "WSASend":
+            buff = self.get_argument(call, "Buffer")
+            for compdetails in self.computerdetails:
+                if compdetails in buff:
+                    if self.computerdetails.count(buff) == 0:
+                        self.data.append({"C2_WSASend": buff})
+                        self.cnc = True
+
+    def on_complete(self):
+        if self.cnc:
+            return True
+
+        return False

--- a/modules/signatures/network_c2_details.py
+++ b/modules/signatures/network_c2_details.py
@@ -22,7 +22,7 @@ class NetworkC2Details(Signature):
     confidence = 20
     categories = ["infostealer","c2","network"]
     authors = ["Kevin Ross"]
-    minimum = "1.3"
+    minimum = "1.2"
     evented = True
 
     def __init__(self, *args, **kwargs):
@@ -50,41 +50,36 @@ class NetworkC2Details(Signature):
             buff = self.get_argument(call, "Buffer")
             for compdetails in self.computerdetails:
                 if compdetails in buff:
-                    if self.computerdetails.count(buff) == 0:
-                        self.data.append({"C2_Preperation_CryptoHashData": buff})
-                        self.cnc = True
+                    self.data.append({"C2_Preperation_CryptoHashData": buff})
+                    self.cnc = True
 
         elif api == "HttpSendRequestW":
             buff = self.get_argument(call, "PostData")
             for compdetails in self.computerdetails:
                 if compdetails in buff:
-                    if self.computerdetails.count(buff) == 0:
-                        self.data.append({"C2_HttpSendRequestW": buff})
-                        self.cnc = True
+                    self.data.append({"C2_HttpSendRequestW": buff})
+                    self.cnc = True
 
         elif api == "HttpOpenRequestW":
             buff = self.get_argument(call, "Path")
             for compdetails in self.computerdetails:
                 if compdetails in buff:
-                    if self.computerdetails.count(buff) == 0:
-                        self.data.append({"C2_HttpOpenRequestW": buff})
-                        self.cnc = True
+                    self.data.append({"C2_HttpOpenRequestW": buff})
+                    self.cnc = True
 
         elif api == "InternetCrackUrlW":
             buff = self.get_argument(call, "Url")
             for compdetails in self.computerdetails:
                 if compdetails in buff:
-                    if self.computerdetails.count(buff) == 0:
-                        self.data.append({"C2_InternetCrackUrlW": buff})
-                        self.cnc = True
+                    self.data.append({"C2_InternetCrackUrlW": buff})
+                    self.cnc = True
 
         elif api == "WSASend":
             buff = self.get_argument(call, "Buffer")
             for compdetails in self.computerdetails:
                 if compdetails in buff:
-                    if self.computerdetails.count(buff) == 0:
-                        self.data.append({"C2_WSASend": buff})
-                        self.cnc = True
+                    self.data.append({"C2_WSASend": buff})
+                    self.cnc = True
 
     def on_complete(self):
         if self.cnc:


### PR DESCRIPTION
This is a conversion of this signature I was playing with: https://github.com/cuckoosandbox/community/pull/120 (I started with cuckoo 2.0 as I was doing a lot with signature conversion so I found it easier to start there and to mark calls).

Anyway this works with Dridex and Upatre currently from what I can see and I am looking for other samples I can use to build on this with. Currently it also only looks for username or computer name being used but again I am looking for more examples to build on with the intention of common bits of C2 information that may be sent about a computer that are good IOCs being targetted. 

The CryptoHashData call in Dridex doesn't show as cleanly as I hoped but it works fine. The intention though is to build upon this sig & cleaning up the reporting to hopefully get to a point where it can communicate some understanding of C2 beacon construction from bits of queried information (maybe once it is more complete and I can see what I am facing describing what bits of information has been used).
