### PR TITLE
Add signature to detect dropping ransom messages

### DIFF
--- a/modules/signatures/ransomware_message.py
+++ b/modules/signatures/ransomware_message.py
@@ -102,7 +102,7 @@ class RansomwareMessage(Signature):
     filter_apinames = set(["NtWriteFile"])
 
     def on_call(self, call, process):
-        if call["api"] == "NtWriteFile" and self.results["info"]["package"] != "pdf":
+        if call["api"] == "NtWriteFile":
             filescore = 0
             buff = self.get_raw_argument(call, "Buffer").lower()
             filepath = self.get_raw_argument(call, "HandleName")
@@ -113,7 +113,7 @@ class RansomwareMessage(Signature):
                         self.ransomfile.append(filepath)
 
     def on_complete(self):
-        if "dropped" in self.results and self.results["info"]["package"] != "pdf":
+        if "dropped" in self.results:
             for dropped in self.results["dropped"]:
                 mimetype = dropped["type"]
                 if "ASCII text" in mimetype:

--- a/modules/signatures/ransomware_message.py
+++ b/modules/signatures/ransomware_message.py
@@ -72,6 +72,7 @@ class RansomwareMessage(Signature):
             "bootkit",
             "rootkit",
             "payment",
+            "victim",
             "AES128",
             "AES256",
             "AES 128",
@@ -107,7 +108,7 @@ class RansomwareMessage(Signature):
             filepath = self.get_raw_argument(call, "HandleName")
             patterns = "|".join(self.indicators)
             if (filepath.lower() == "\\??\\physicaldrive0" or filepath.lower().startswith("\\device\\harddisk")) and len(buff) >= 128:
-                if re.findall(patterns, buff):   
+                if len(re.findall(patterns, buff)) > 1:   
                     if filepath not in self.ransomfile:
                         self.ransomfile.append(filepath)
 
@@ -120,7 +121,7 @@ class RansomwareMessage(Signature):
                     data = dropped["data"]
                     patterns = "|".join(self.indicators)
                     if len(data) >= 128:
-                        if re.findall(patterns, data):
+                        if len(re.findall(patterns, data)) > 1:
                             if filename not in self.ransomfile:
                                 self.ransomfile.append(filename)
 

--- a/modules/signatures/ransomware_message.py
+++ b/modules/signatures/ransomware_message.py
@@ -66,6 +66,8 @@ class RansomwareMessage(Signature):
             "torgateway",
             "torproject.org",
             "ransom",
+            "bootkit",
+            "rootkit",
             "payment",
             "AES128",
             "AES256",
@@ -84,7 +86,11 @@ class RansomwareMessage(Signature):
             "RSA-4096",
             "private key",
             "personal key",
-            "your key"
+            "your code",
+            "private code",
+            "personal code",
+            "enter code",
+            "your key",
             "unique key"
     ]
         
@@ -94,14 +100,12 @@ class RansomwareMessage(Signature):
     def on_call(self, call, process):
         if call["api"] == "NtWriteFile":
             filescore = 0
-            buff = self.get_raw_argument(call, "Buffer")
-            for indicator in self.indicators:
-                if indicator in buff.lower():
-                    filescore += 1
-                if filescore > 1:
-                    filepath = self.get_raw_argument(call, "HandleName")
-                    if filepath not in self.ransomfile:
-                        self.ransomfile.append(filepath)
+            buff = self.get_raw_argument(call, "Buffer").lower()
+            patterns = "|".join(self.indicators)
+            if re.findall(patterns, buff):
+                filepath = self.get_raw_argument(call, "HandleName")
+                if filepath not in self.ransomfile:
+                    self.ransomfile.append(filepath)
 
     def on_complete(self):
         if len(self.ransomfile) > 0:

--- a/modules/signatures/ransomware_message.py
+++ b/modules/signatures/ransomware_message.py
@@ -102,7 +102,7 @@ class RansomwareMessage(Signature):
     filter_apinames = set(["NtWriteFile"])
 
     def on_call(self, call, process):
-        if call["api"] == "NtWriteFile":
+        if call["api"] == "NtWriteFile" and self.results["info"]["package"] != "pdf":
             filescore = 0
             buff = self.get_raw_argument(call, "Buffer").lower()
             filepath = self.get_raw_argument(call, "HandleName")
@@ -113,7 +113,7 @@ class RansomwareMessage(Signature):
                         self.ransomfile.append(filepath)
 
     def on_complete(self):
-        if "dropped" in self.results:
+        if "dropped" in self.results and self.results["info"]["package"] != "pdf":
             for dropped in self.results["dropped"]:
                 mimetype = dropped["type"]
                 if "ASCII text" in mimetype:

--- a/modules/signatures/ransomware_message.py
+++ b/modules/signatures/ransomware_message.py
@@ -106,7 +106,7 @@ class RansomwareMessage(Signature):
             buff = self.get_raw_argument(call, "Buffer").lower()
             filepath = self.get_raw_argument(call, "HandleName")
             patterns = "|".join(self.indicators)
-            if filepath.lower() == "\\??\\physicaldrive0" or filepath.lower().startswith("\\device\\harddisk"):
+            if (filepath.lower() == "\\??\\physicaldrive0" or filepath.lower().startswith("\\device\\harddisk")) and len(buff) >= 128:
                 if re.findall(patterns, buff):   
                     if filepath not in self.ransomfile:
                         self.ransomfile.append(filepath)
@@ -119,9 +119,10 @@ class RansomwareMessage(Signature):
                     filename = dropped["name"]
                     data = dropped["data"]
                     patterns = "|".join(self.indicators)
-                    if re.findall(patterns, data):
-                        if filename not in self.ransomfile:
-                            self.ransomfile.append(filename)
+                    if len(data) >= 128:
+                        if re.findall(patterns, data):
+                            if filename not in self.ransomfile:
+                                self.ransomfile.append(filename)
 
         if len(self.ransomfile) > 0:
             for filename in self.ransomfile:

--- a/modules/signatures/ransomware_message.py
+++ b/modules/signatures/ransomware_message.py
@@ -1,0 +1,112 @@
+# Copyright (C) 2016 Kevin Ross
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from lib.cuckoo.common.abstracts import Signature
+
+try:
+    import re2 as re
+except ImportError:
+    import re
+
+class RansomwareMessage(Signature):
+    name = "ransomware_message"
+    description = "Writes a potential ransom message to disk"
+    severity = 3
+    categories = ["ransomware"]
+    authors = ["Kevin Ross"]
+    minimum = "1.3"
+    evented = True
+    match = True
+
+    def __init__(self, *args, **kwargs):
+        Signature.__init__(self, *args, **kwargs)
+        self.ransomfile = []
+        self.indicators = [
+            "your files",
+            "your data",
+            "your documents",
+            "restore files",
+            "restore data",
+            "restore your data",
+            "has been locked",
+            "pay fine",
+            "pay a fine",
+            "pay the fine",
+            "decrypt",
+            "encrypt",
+            "recover files",
+            "recover data",
+            "recover them",
+            "recover your",
+            "recover personal",
+            "recover the files",
+            "recover the data",
+            "bitcoin",
+            "secret server",
+            "secret internet server",
+            "install tor",
+            "download tor",
+            "tor browser",
+            "tor gateway",
+            "tor-browser",
+            "tor-gateway",
+            "torbrowser",
+            "torgateway",
+            "torproject.org",
+            "ransom",
+            "payment",
+            "AES128",
+            "AES256",
+            "AES 128",
+            "AES 256",
+            "AES-128",
+            "AES-256",
+            "RSA1024",
+            "RSA2048",
+            "RSA4096",
+            "RSA 1024",
+            "RSA 2048",
+            "RSA 4096",
+            "RSA-1024",
+            "RSA-2048",
+            "RSA-4096",
+            "private key",
+            "personal key",
+            "your key"
+            "unique key"
+    ]
+        
+
+    filter_apinames = set(["NtWriteFile"])
+
+    def on_call(self, call, process):
+        if call["api"] == "NtWriteFile":
+            filescore = 0
+            buff = self.get_raw_argument(call, "Buffer")
+            for indicator in self.indicators:
+                if indicator in buff.lower():
+                    filescore += 1
+                if filescore > 1:
+                    filepath = self.get_raw_argument(call, "HandleName")
+                    if filepath not in self.ransomfile:
+                        self.ransomfile.append(filepath)
+
+    def on_complete(self):
+        if len(self.ransomfile) > 0:
+            for filename in self.ransomfile:
+                self.data.append({"ransom_file" : "%s" % (filename)})
+            return True
+
+        return False


### PR DESCRIPTION
First version of a signature to detect files writing likely ransomware messages to disk. Currently once I have it I just output the filename; the later intention is to extract the filename itself rather than the whole path but I was having difficulty getting it to work right. 

That would be preferable as ransomware messages typically are the same file dropped throughout the filesystem so just getting the file will take the list down from dozens to likely just one once it is working but I will look at sorting that up another time as this signature works for now and tried against a few ransomware families.
