### PR TITLE
Remove FP

### DIFF
--- a/modules/signatures/antidbg_windows.py
+++ b/modules/signatures/antidbg_windows.py
@@ -66,7 +66,6 @@ class AntiDBGWindows(Signature):
             "ThunderRT6FormDC",
             "TfrmMain",
             "Afx:400000:b:10011:6:350167",
-            "TApplication",
             "SmartSniff",
             "ConsoleWindowClass",
             "18467-41",


### PR DESCRIPTION
Any Borland C++ GUI app tries to create this window name.
