### PR TITLE
Add in command processor location

### DIFF
--- a/modules/signatures/persistence_autorun.py
+++ b/modules/signatures/persistence_autorun.py
@@ -76,6 +76,7 @@ class Autorun(Signature):
             ".*\\\\System\\\\(CurrentControlSet|ControlSet001)\\\\Control\\\\Session\\ Manager\\\\AppCertDlls\\\\.*",
             ".*\\\\Software\\\\(Wow6432Node\\\\)?Classes\\\\clsid\\\\[^\\\\]*\\\\InprocServer32\\\\.*",
             ".*\\\\Software\\\\(Wow6432Node\\\\)?Classes\\\\clsid\\\\[^\\\\]*\\\\LocalServer32\\\\.*"
+            ".*\\\\Microsoft\\\\Windows\\ Microsoft\\\\Command\\ Processor\\\\AutoRun$",
             ]
         whitelists = [
             ".*\\\\Software\\\\(Wow6432Node\\\\)?Classes\\\\clsid\\\\{CAFEEFAC-0017-0000-FFFF-ABCDEFFEDCBA}\\\\InprocServer32\\\\.*",

--- a/modules/signatures/persistence_autorun.py
+++ b/modules/signatures/persistence_autorun.py
@@ -76,7 +76,7 @@ class Autorun(Signature):
             ".*\\\\System\\\\(CurrentControlSet|ControlSet001)\\\\Control\\\\Session\\ Manager\\\\AppCertDlls\\\\.*",
             ".*\\\\Software\\\\(Wow6432Node\\\\)?Classes\\\\clsid\\\\[^\\\\]*\\\\InprocServer32\\\\.*",
             ".*\\\\Software\\\\(Wow6432Node\\\\)?Classes\\\\clsid\\\\[^\\\\]*\\\\LocalServer32\\\\.*",
-            ".*\\\\Microsoft\\\\Windows\\ Microsoft\\\\Command\\ Processor\\\\AutoRun$"
+            ".*\\\\Microsoft\\\\Command\\ Processor\\\\AutoRun$"
             ]
         whitelists = [
             ".*\\\\Software\\\\(Wow6432Node\\\\)?Classes\\\\clsid\\\\{CAFEEFAC-0017-0000-FFFF-ABCDEFFEDCBA}\\\\InprocServer32\\\\.*",

--- a/modules/signatures/persistence_autorun.py
+++ b/modules/signatures/persistence_autorun.py
@@ -75,8 +75,8 @@ class Autorun(Signature):
             ".*\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\ShellServiceObjectDelayLoad\\\\.*",
             ".*\\\\System\\\\(CurrentControlSet|ControlSet001)\\\\Control\\\\Session\\ Manager\\\\AppCertDlls\\\\.*",
             ".*\\\\Software\\\\(Wow6432Node\\\\)?Classes\\\\clsid\\\\[^\\\\]*\\\\InprocServer32\\\\.*",
-            ".*\\\\Software\\\\(Wow6432Node\\\\)?Classes\\\\clsid\\\\[^\\\\]*\\\\LocalServer32\\\\.*"
-            ".*\\\\Microsoft\\\\Windows\\ Microsoft\\\\Command\\ Processor\\\\AutoRun$",
+            ".*\\\\Software\\\\(Wow6432Node\\\\)?Classes\\\\clsid\\\\[^\\\\]*\\\\LocalServer32\\\\.*",
+            ".*\\\\Microsoft\\\\Windows\\ Microsoft\\\\Command\\ Processor\\\\AutoRun$"
             ]
         whitelists = [
             ".*\\\\Software\\\\(Wow6432Node\\\\)?Classes\\\\clsid\\\\{CAFEEFAC-0017-0000-FFFF-ABCDEFFEDCBA}\\\\InprocServer32\\\\.*",


### PR DESCRIPTION
Mentioned here: https://www.fireeye.com/blog/threat-research/2016/07/cerber-ransomware-attack.html

"The malware configures multiple concurrent persistence mechanisms by creating command processor, screensaver, startup.run and runonce registry entries."

More info https://blogs.msdn.microsoft.com/oldnewthing/20071121-00/?p=24433
