### PR TITLE
Create signature for spawning/injecting many processes

### DIFF
--- a/modules/signatures/creates_excessproc.py
+++ b/modules/signatures/creates_excessproc.py
@@ -1,0 +1,37 @@
+# Copyright (C) 2016 Kevin Ross
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from lib.cuckoo.common.abstracts import Signature
+
+class LargeProcessCount(Signature):
+    name = "large_process_count"
+    description = "Creates or injects into an excessive number of processes"
+    severity = 2
+    confidence = 50
+    categories = ["generic"]
+    authors = ["Kevin Ross"]
+    minimum = "1.3"
+
+    def run(self):
+        if "behavior" in self.results and "processes" in self.results["behavior"]:
+            processcount = len(self.results["behavior"]["processes"])
+            if processcount - 1 >= 20:
+                self.description = "Creates or injects into a large number of processes"
+                self.severity = 3
+                return True
+            elif processcount - 1 >= 10:
+                return True
+
+        return False


### PR DESCRIPTION
This is a simple signature to detect malware with large process trees. One indicator for malware is lots of processes, this includes injection, creation or even running command windows etc as well as malware trying to be evasive (or rather annoying when viewing) by spawning large process trees from copies of itself. 

Anyway as mentioned simple and just take action based on the number of processes minus 1 for the parent process. Tested on various samples. I pondered whether or not to display the processes as appended information but decided against it as wasted processing time as user can click on behavior tab and see them anyway one this has been highlighted to them.

Also on a side note any feedback regarding the ransomware message submission now the suggested improvements have been made and tested as not had feedback since?
