### PR TITLE
Remove FP triggered by MS Office apps

### DIFF
--- a/modules/signatures/infostealer_mail.py
+++ b/modules/signatures/infostealer_mail.py
@@ -13,6 +13,10 @@ class EmailStealer(Signature):
     minimum = "1.2"
 
     def run(self):
+        office_pkgs = ["ppt","doc","xls","eml"]
+        if any(e in self.results["info"]["package"] for e in office_pkgs):
+            return False
+
         file_indicators = [
             ".*\.pst$",
             ".*\\\\Microsoft\\\\Windows\\ Live\\ Mail.*",


### PR DESCRIPTION
MS Office apps trigger this signature with the following registry keys:

HKEY_LOCAL_MACHINE\Software\Clients\Mail
HKEY_LOCAL_MACHINE\SOFTWARE\Clients\Mail(Default)
