### PR TITLE
Fixes errors when no dropped files exist.

### DIFF
--- a/modules/signatures/copies_self.py
+++ b/modules/signatures/copies_self.py
@@ -36,11 +36,12 @@ class CopiesSelf(Signature):
             initialpath = initialproc["module_path"].lower()
         target_sha1 = self.results["target"]["file"]["sha1"]
 
-        for drop in self.results["dropped"]:
-            if drop["sha1"] == target_sha1:
-                for path in drop["guest_paths"]:
-                    if initialpath and initialpath != path.lower():
-                        self.data.append({"copy" : path})
-                        created_copy = True
-                return created_copy
+        if self.results["dropped"]:
+            for drop in self.results["dropped"]:
+                if drop["sha1"] == target_sha1:
+                    for path in drop["guest_paths"]:
+                        if initialpath and initialpath != path.lower():
+                            self.data.append({"copy" : path})
+                            created_copy = True
+                    return created_copy
         return created_copy

--- a/modules/signatures/polymorphic.py
+++ b/modules/signatures/polymorphic.py
@@ -44,24 +44,25 @@ class Polymorphic(Signature):
         if target_ssdeep == "" or target_ssdeep == None:
             return False
 
-        for drop in self.results["dropped"]:
-            if package == "xls" and len(drop["guest_paths"]) == 1 and drop["guest_paths"][0].endswith("\\Temp\\" + self.results["target"]["file"]["name"]):
-                continue
-            if drop["sha1"] == target_sha1:
-                continue
-            if fabs(target_size - drop["size"]) >= 1024:
-                continue
-            drop_ssdeep = drop["ssdeep"]
-            if drop_ssdeep == "" or drop_ssdeep == None:
-                continue
-            try:
-                percent = pydeep.compare(target_ssdeep, drop_ssdeep)
-                if percent > 20:
-                    found_polymorphic = True
-                    for path in drop["guest_paths"]:
-                        self.data.append({"file" : path})
-                    self.data.append({"percent_match" : percent})
-            except:
-                continue
+        if self.results["dropped"]:
+            for drop in self.results["dropped"]:
+                if package == "xls" and len(drop["guest_paths"]) == 1 and drop["guest_paths"][0].endswith("\\Temp\\" + self.results["target"]["file"]["name"]):
+                    continue
+                if drop["sha1"] == target_sha1:
+                    continue
+                if fabs(target_size - drop["size"]) >= 1024:
+                    continue
+                drop_ssdeep = drop["ssdeep"]
+                if drop_ssdeep == "" or drop_ssdeep == None:
+                    continue
+                try:
+                    percent = pydeep.compare(target_ssdeep, drop_ssdeep)
+                    if percent > 20:
+                        found_polymorphic = True
+                        for path in drop["guest_paths"]:
+                            self.data.append({"file" : path})
+                        self.data.append({"percent_match" : percent})
+                except:
+                    continue
 
         return found_polymorphic


### PR DESCRIPTION
Fixes errors as noticed in several files where no dropped files exist:

2016-09-01 14:29:22,775 [lib.cuckoo.core.plugins] ERROR: Failed to run signature "copies_self":
Traceback (most recent call last):
  File "/opt/cuckoo-modified/utils/../lib/cuckoo/core/plugins.py", line 351, in process
    data = current.run()
  File "/opt/cuckoo-modified/utils/../modules/signatures/copies_self.py", line 39, in run
    for drop in self.results["dropped"]:
KeyError: 'dropped'
2016-09-01 14:29:22,881 [lib.cuckoo.core.plugins] ERROR: Failed to run signature "polymorphic":
Traceback (most recent call last):
  File "/opt/cuckoo-modified/utils/../lib/cuckoo/core/plugins.py", line 351, in process
    data = current.run()
  File "/opt/cuckoo-modified/utils/../modules/signatures/polymorphic.py", line 47, in run
    for drop in self.results["dropped"]:
KeyError: 'dropped'
