### PR TITLE
Dedup matches, remove whitespace

### DIFF
--- a/modules/signatures/ransomware_message.py
+++ b/modules/signatures/ransomware_message.py
@@ -97,7 +97,7 @@ class RansomwareMessage(Signature):
             "your key",
             "unique key"
     ]
-        
+
 
     filter_apinames = set(["NtWriteFile"])
 
@@ -108,7 +108,7 @@ class RansomwareMessage(Signature):
             filepath = self.get_raw_argument(call, "HandleName")
             patterns = "|".join(self.indicators)
             if (filepath.lower() == "\\??\\physicaldrive0" or filepath.lower().startswith("\\device\\harddisk")) and len(buff) >= 128:
-                if len(re.findall(patterns, buff)) > 1:   
+                if len(set(re.findall(patterns, buff))) > 1:
                     if filepath not in self.ransomfile:
                         self.ransomfile.append(filepath)
 
@@ -121,7 +121,7 @@ class RansomwareMessage(Signature):
                     data = dropped["data"]
                     patterns = "|".join(self.indicators)
                     if len(data) >= 128:
-                        if len(re.findall(patterns, data)) > 1:
+                        if len(set(re.findall(patterns, data))) > 1:
                             if filename not in self.ransomfile:
                                 self.ransomfile.append(filename)
 


### PR DESCRIPTION
Otherwise this will detect dropped files which have 'encrypt' in them twice or similar. Various .css templates were FP'ing on this signature. May need to refine this more in the future but this is sufficient in my current dataset.
