### PR TITLE
Remove FP with URL Analyses

### DIFF
--- a/modules/signatures/infostealer_mail.py
+++ b/modules/signatures/infostealer_mail.py
@@ -28,7 +28,6 @@ class EmailStealer(Signature):
             ".*\\\\AppData\\\\Roaming\\\\Thunderbird\\\\profiles.ini$",
         ]
         registry_indicators = [
-            ".*\\\\Software\\\\(Wow6432Node\\\\)?Clients\\\\Mail.*",
             ".*\\\\Microsoft\\\\Windows\\ Messaging\\ Subsystem\\\\MSMapiApps.*",
             ".*\\\\Microsoft\\\\Windows\\ Messaging\\ Subsystem\\\\Profiles.*",
             ".*\\\\Microsoft\\\\Windows\\ NT\\\\CurrentVersion\\\\Windows\\ Messaging\\ Subsystem\\\\Profiles.*",
@@ -38,6 +37,9 @@ class EmailStealer(Signature):
             ".*\\\\Software\\\\(Wow6432Node\\\\)?IncrediMail.*"
             ".*\\\\Software\\\\(Wow6432Node\\\\)?Microsoft\\\\Windows\\ Live\\ Mail.*",
         ]
+        if self.results["target"]["category"] == "file":
+            registry_indicators.append(".*\\\\Software\\\\(Wow6432Node\\\\)?Clients\\\\Mail.*")
+            
         found_stealer = False
         for indicator in file_indicators:
             file_match = self.check_file(pattern=indicator, regex=True, all=True)


### PR DESCRIPTION
Should probably turn this signature into an evented signature, where we remove this FP from internet explorer processors only. This works for my purposes however.

FP Keys:
HKEY_LOCAL_MACHINE\SOFTWARE\Clients\Mail\Microsoft Outlook\Capabilities\Hidden
HKEY_LOCAL_MACHINE\Software\Clients\Mail\Microsoft Outlook\Capabilities
HKEY_LOCAL_MACHINE\SOFTWARE\Clients\Mail\Microsoft Outlook\Capabilities\UrlAssociations