### PR TITLE
Fix a traceback

### DIFF
--- a/modules/signatures/hawkeye_apis.py
+++ b/modules/signatures/hawkeye_apis.py
@@ -86,16 +86,17 @@ class HawkEye_APIs(Signature):
                     self.sockets[sock]["data"] = list()
 
         elif call["api"] == "send":
-            buf = self.get_argument(call, "buffer")
             sock = self.get_argument(call, "socket")
-            tmp = unbuffered_b64decode(buf)
-            for term in self.emailterms:
-                if term in buf.lower() or term in tmp.lower():
-                    self.badness += 10
-            for word in self.keywords:
-                if buf.startswith(word):
-                    self.sockets[sock]["data"].append(buf)
-                    self.badsocks.add(sock)
+            if sock in self.sockets:
+                buf = self.get_argument(call, "buffer")
+                tmp = unbuffered_b64decode(buf)
+                for term in self.emailterms:
+                    if term in buf.lower() or term in tmp.lower():
+                        self.badness += 10
+                for word in self.keywords:
+                    if buf.startswith(word):
+                        self.sockets[sock]["data"].append(buf)
+                        self.badsocks.add(sock)
 
         elif call["api"] == "NtCreateEvent":
             evname = self.get_argument(call, "EventName")


### PR DESCRIPTION
Is possible for other sockets to be created via an API which is not checked (connect/connectex for example) if this happens, you'll get a key error when attempting to set a buffer to a socket that we aren't tracking since we only care about sockets created using the WSAConnect API