### PR TITLE
Fix traceback, sanity check

### DIFF
--- a/modules/signatures/dead_connect.py
+++ b/modules/signatures/dead_connect.py
@@ -49,11 +49,12 @@ class DeadConnect(Signature):
 
             for deadip in self.connections:
                 ip = deadip.split(":")[0]
-                hostdata = next((i for i in self.results["network"]["hosts"] if i["ip"] == ip), None)
-                if hostdata:
-                    self.data.append({"IP": "{0} ({1})".format(deadip, hostdata["country_name"])})
-                else:
-                    self.data.append({"IP": deadip})
+                if "hosts" in self.results["network"]:
+                    hostdata = next((i for i in self.results["network"]["hosts"] if i["ip"] == ip), None)
+                    if hostdata:
+                        self.data.append({"IP": "{0} ({1})".format(deadip, hostdata["country_name"])})
+                    else:
+                        self.data.append({"IP": deadip})
 
             return True
 


### PR DESCRIPTION
The hosts key may not exist. One example being when reprocessing an analysis where the retention module deleted a PCAP.