### PR TITLE
Add in Revenge ransomware

### DIFF
--- a/modules/signatures/ransomware_fileextensions.py
+++ b/modules/signatures/ransomware_fileextensions.py
@@ -80,6 +80,7 @@ class RansomwareExtensions(Signature):
             (".*\.sage$", ["Sage"]),
             (".*\.CRYPTOSHIELD$", ["CryptoShield"]),
             (".*\.serpent$", ["Serpent"]),
+            (".*\.REVENGE$", ["Revenge"]),
         ]
 
         for indicator in indicators:


### PR DESCRIPTION
CryptoMix variant distributed by RIG EK:

https://www.bleepingcomputer.com/news/security/revenge-ransomware-a-cryptomix-variant-being-distributed-by-rig-exploit-kit/
http://www.broadanalysis.com/2017/03/14/rig-exploit-kit-via-the-eitest-delivers-cryptoshieldrevenge-ransomware/