### PR TITLE
Add in Mordor, CryptoMix & Jaff extensions

### DIFF
--- a/modules/signatures/ransomware_fileextensions.py
+++ b/modules/signatures/ransomware_fileextensions.py
@@ -78,6 +78,7 @@ class RansomwareExtensions(Signature):
             (".*\.sexy$", ["PayDay"]),
             (".*\.kraken$", ["Kraken"]),
             (".*\.lesli$", ["CryptoMix"]),
+            (".*\.WALLET$", ["CryptoMix"]),
             (".*\.sage$", ["Sage"]),
             (".*\.CRYPTOSHIELD$", ["CryptoShield"]),
             (".*\.serpent$", ["Serpent"]),
@@ -85,6 +86,7 @@ class RansomwareExtensions(Signature):
             (".*\.MOLE$", ["Mole"]),
             (".*\.onion$", ["Dharma"]),
             (".*\.grt$", ["Karmen"]),
+            (".*\.mordor$", ["Mordor"]),
         ]
 
         for indicator in indicators:

--- a/modules/signatures/ransomware_fileextensions.py
+++ b/modules/signatures/ransomware_fileextensions.py
@@ -87,6 +87,7 @@ class RansomwareExtensions(Signature):
             (".*\.onion$", ["Dharma"]),
             (".*\.grt$", ["Karmen"]),
             (".*\.mordor$", ["Mordor"]),
+            (".*\.jaff$", ["Jaff"]),
         ]
 
         for indicator in indicators:


### PR DESCRIPTION
Just some additional extensions. On another note what is people's views on clearing out some of the older extensions from earlier versions of families (i.e. Locky has 8 IOCs alone yet only osiris is being used). There is an argument to be made for older variants being identified as part of research but I am wondering about performance.